### PR TITLE
Use absolute path with test method

### DIFF
--- a/lib/capistrano/tasks/docker.rake
+++ b/lib/capistrano/tasks/docker.rake
@@ -54,7 +54,7 @@ namespace :docker do
 
       message host, "Starting #{container_name}"
       within release_path do
-        if test "[ -x bin/docker-start ]"
+        if test "[ -x #{release_path}/bin/docker-start ]"
           execute( "bin/docker-start",
                    "--name #{container_name}",
                    "--image #{fetch( :image_name )}" )


### PR DESCRIPTION
It doesn't look like it respects the current path. Not sure if it's an sshkit bug or if its expected.

https://github.com/capistrano/sshkit/blob/6c81f53eec86443ea4f03fd87ae3350d4d4051ec/lib/sshkit/backends/abstract.rb#L50
